### PR TITLE
Restore cluster configuration template functionality

### DIFF
--- a/recipes/configure_server.rb
+++ b/recipes/configure_server.rb
@@ -104,7 +104,7 @@ end
 
 # setup the main server config file
 template percona["main_config_file"] do
-  source "my.cnf.#{node["role"] == "cluster" ? "cluster" : "main"}.erb"
+  source "my.cnf.#{node["percona"]["server"]["role"] == "cluster" ? "cluster" : "main"}.erb"
   owner "root"
   group "root"
   mode "0644"

--- a/recipes/configure_server.rb
+++ b/recipes/configure_server.rb
@@ -104,7 +104,7 @@ end
 
 # setup the main server config file
 template percona["main_config_file"] do
-  source "my.cnf.main.erb"
+  source "my.cnf.#{node["role"] == "cluster" ? "cluster" : "main"}.erb"
   owner "root"
   group "root"
   mode "0644"

--- a/recipes/configure_server.rb
+++ b/recipes/configure_server.rb
@@ -104,7 +104,7 @@ end
 
 # setup the main server config file
 template percona["main_config_file"] do
-  source "my.cnf.#{node["percona"]["server"]["role"] == "cluster" ? "cluster" : "main"}.erb"
+  source "my.cnf.#{server["role"] == "cluster" ? "cluster" : "main"}.erb"
   owner "root"
   group "root"
   mode "0644"


### PR DESCRIPTION
This is a fix for #199, to address the regression of cluster configuration support caused by https://github.com/phlipper/chef-percona/commit/57c16b23eec40292b96d4806d7fd3e4cd583e066