### PR TITLE
Add support for chef-vault for passwords

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,7 @@ default["percona"]["main_config_file"]                          = value_for_plat
 default["percona"]["keyserver"]                                 = "keys.gnupg.net"
 default["percona"]["encrypted_data_bag"]                        = "passwords"
 default["percona"]["encrypted_data_bag_secret_file"]            = ""
+default["percona"]["use_chef-vault"]                            = false
 default["percona"]["use_percona_repos"]                         = true
 
 # Start percona server on boot

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -35,6 +35,7 @@ default["percona"]["main_config_file"]                          = value_for_plat
 default["percona"]["keyserver"]                                 = "keys.gnupg.net"
 default["percona"]["encrypted_data_bag"]                        = "passwords"
 default["percona"]["encrypted_data_bag_secret_file"]            = ""
+default["percona"]["use_chef-vault"]                            = false
 default["percona"]["skip_passwords"]                            = false
 default["percona"]["skip_configure"]                            = false
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -23,6 +23,7 @@ depends "build-essential"
 depends "openssl"
 depends "yum", "~> 3.0"
 depends "yum-epel"
+depends "chef-vault"
 
 supports "debian"
 supports "ubuntu"

--- a/recipes/configure_server.rb
+++ b/recipes/configure_server.rb
@@ -8,6 +8,9 @@ server  = percona["server"]
 conf    = percona["conf"]
 mysqld  = (conf && conf["mysqld"]) || {}
 
+# install chef-vault if needed
+include_recipe "chef-vault" if node["percona"]["use_chef-vault"]
+
 # construct an encrypted passwords helper -- giving it the node and bag name
 passwords = EncryptedPasswords.new(node, percona["encrypted_data_bag"])
 


### PR DESCRIPTION
This patch adds support for Chef-Vault for passwords. A new attribute "use_chef-vault" controls the logic and defaults to false. When set to true, Chef-Vault is used instead of accessing encrypted data bags directly. Chef-Vault is an overlay to encrypted data bags which makes it easier to control which nodes have access to decrypting passwords.

I made the error message in libraries/passwords.rb a bit more verbose, to make it clearer that an attempt to retrieve the password from a data bag failed. To get the CI build to pass I had to shorten the name of the method "data_bag_secret" to just "secret" to get line length below 80.

Tested on CentOS 7.