### PR TITLE
Fix package list for clusters based on CentOS

### DIFF
--- a/attributes/client.rb
+++ b/attributes/client.rb
@@ -20,7 +20,14 @@ when "debian"
     libperconaserverclient#{abi_version}-dev percona-server-client-#{version}
   ]
 when "rhel"
-  default["percona"]["client"]["packages"] = %W[
-    Percona-Server-devel-#{version} Percona-Server-client-#{version}
-  ]
+  case node["percona"]["server"]["role"]
+  when "standalone"
+    default["percona"]["client"]["packages"] = %W[
+      Percona-Server-devel-#{version} Percona-Server-client-#{version}
+    ]
+  when "cluster"
+    default["percona"]["client"]["packages"] = %W[
+      Percona-XtraDB-Cluster-devel-#{version} Percona-XtraDB-Cluster-client-#{version}
+    ]
+  end
 end


### PR DESCRIPTION
The client recipe defines a list of packages to install. Both the -devel and -client packages have XtraDB Cluster counterparts, so use them instead if setting up a cluster.