### PR TITLE
Fix openssl dependency due to openssl commit 03e0e9b690fd9

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -20,7 +20,7 @@ recipe "percona::monitoring", "Installs Percona monitoring plugins for Nagios"
 
 depends "apt", ">= 1.9"
 depends "build-essential"
-depends "openssl"
+depends "openssl", "< 3.0.0"
 depends "yum", "~> 3.0"
 depends "yum-epel"
 


### PR DESCRIPTION
The OpenSSL cookbook just renamed the helper module name from Opscode to OpenSSLCookbook, but the change does not seem to work as expected, at least not yet. Therefore my commit locks the openssl dependency to versions prior to 3.0.0.

Problematic OpenSSL cookbook commit: https://github.com/opscode-cookbooks/openssl/commit/03e0e9b690fd9db3d81779762c810371f0fe7e1e