### PR TITLE
Add optional config entries for my.cnf variables

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -73,6 +73,8 @@ default["percona"]["server"]["connect_timeout"]                 = 10
 default["percona"]["server"]["wait_timeout"]                    = 28_800
 default["percona"]["server"]["old_passwords"]                   = 0
 default["percona"]["server"]["bind_address"]                    = "127.0.0.1"
+default["percona"]["server"]["federated"]                       = false
+
 %w[debian_password root_password].each do |attribute|
   next if attribute?(node["percona"]["server"][attribute])
   default["percona"]["server"][attribute]                       = secure_password
@@ -97,6 +99,7 @@ default["percona"]["server"]["sql_modes"]                       = []
 default["percona"]["server"]["table_cache"]                     = 8192
 default["percona"]["server"]["group_concat_max_len"]            = 4096
 default["percona"]["server"]["expand_fast_index_creation"]      = false
+default["percona"]["server"]["read_rnd_buffer_size"]            = 262144
 
 # Query Cache Configuration
 default["percona"]["server"]["query_cache_size"]                = "64M"

--- a/templates/default/my.cnf.cluster.erb
+++ b/templates/default/my.cnf.cluster.erb
@@ -55,6 +55,10 @@ slave_load_tmpdir = <%= node["percona"]["server"]["tmpdir"] %>
 character_set_server = <%= node["percona"]["server"]["character_set"] %>
 collation_server  = <%= node["percona"]["server"]["collation"] %>
 
+<% if node["percona"]["server"]["federated"] %>
+federated
+<% end %>
+
 <% if node["percona"]["server"]["skip_name_resolve"] %>
 skip-name-resolve
 <% end %>
@@ -118,8 +122,13 @@ group_concat_max_len = <%= node["percona"]["server"]["group_concat_max_len"] %>
 
 <% if node["percona"]["server"]["expand_fast_index_creation"] %>
 expand_fast_index_creation
-
 <% end %>
+
+<% if node["percona"]["server"]["read_rnd_buffer_size"] %>
+# used for some sorts to optimally read rows after the sort
+read_rnd_buffer_size = <%= node["percona"]["server"]["read_rnd_buffer_size"] %>
+<% end %>
+
 # Thread stack size to use. This amount of memory is always reserved at
 # connection time. MySQL itself usually needs no more than 64K of
 # memory, while if you use your own stack hungry UDF functions or your

--- a/templates/default/my.cnf.main.erb
+++ b/templates/default/my.cnf.main.erb
@@ -58,6 +58,10 @@ slave_load_tmpdir = <%= node["percona"]["server"]["tmpdir"] %>
 character_set_server = <%= node["percona"]["server"]["character_set"] %>
 collation_server  = <%= node["percona"]["server"]["collation"] %>
 
+<% if node["percona"]["server"]["federated"] %>
+federated
+<% end %>
+
 <% if node["percona"]["server"]["skip_name_resolve"] %>
 skip-name-resolve
 <% end %>
@@ -101,6 +105,11 @@ group_concat_max_len = <%= node["percona"]["server"]["group_concat_max_len"] %>
 
 <% if node["percona"]["server"]["expand_fast_index_creation"] %>
 expand_fast_index_creation
+<% end %>
+
+<% if node["percona"]["server"]["read_rnd_buffer_size"] %>
+# used for some sorts to optimally read rows after the sort
+read_rnd_buffer_size = <%= node["percona"]["server"]["read_rnd_buffer_size"] %>
 <% end %>
 
 # Thread stack size to use. This amount of memory is always reserved at


### PR DESCRIPTION
federated: enable accessing tables on other mysql server instances
read_rnd_buffer_size: used for some sorts to optimally read rows after the sort