### PR TITLE
Avoid uninstall of mysql-libs (i.e. Percona shared package) when not needed

### DIFF
--- a/recipes/cluster.rb
+++ b/recipes/cluster.rb
@@ -26,6 +26,7 @@ when "debian"
 when "rhel"
   package "mysql-libs" do
     action :remove
+    not_if "rpm -qa | grep -q '#{node["percona"]["cluster"]["package"]}'"
   end
 
   # This is required for `socat` per:


### PR DESCRIPTION
Check if Percona XtraDB Cluster package is installed before removing "mysql-libs" on CentOS/RHEL, to avoid uninstall and reinstall of the Percona packages on every chef-client run.

Tested on CentOS 7.