### PR TITLE
Adding support for sensitive flag changes

### DIFF
--- a/recipes/access_grants.rb
+++ b/recipes/access_grants.rb
@@ -17,6 +17,7 @@ template "/etc/mysql/grants.sql" do
   owner "root"
   group "root"
   mode "0600"
+  sensitive true if Chef::Resource::Template.method_defined? :sensitive
 end
 
 # execute access grants
@@ -28,6 +29,7 @@ if passwords.root_password && !passwords.root_password.empty?
     command "/usr/bin/mysql -p'#{passwords.root_password}' -e '' &> /dev/null > /dev/null &> /dev/null ; if [ $? -eq 0 ] ; then /usr/bin/mysql -p'#{passwords.root_password}' < /etc/mysql/grants.sql ; else /usr/bin/mysql < /etc/mysql/grants.sql ; fi ;" # rubocop:disable LineLength
     action :nothing
     subscribes :run, resources("template[/etc/mysql/grants.sql]"), :immediately
+    sensitive true if Chef::Resource::Execute.method_defined? :sensitive
   end
 else
   # Simpler path...  just try running the grants command
@@ -35,5 +37,6 @@ else
     command "/usr/bin/mysql < /etc/mysql/grants.sql"
     action :nothing
     subscribes :run, resources("template[/etc/mysql/grants.sql]"), :immediately
+    sensitive true if Chef::Resource::Execute.method_defined? :sensitive
   end
 end

--- a/recipes/configure_server.rb
+++ b/recipes/configure_server.rb
@@ -17,6 +17,7 @@ template "/root/.my.cnf" do
   group "root"
   mode "0600"
   source "my.cnf.root.erb"
+  sensitive true if Chef::Resource::Template.method_defined? :sensitive
   not_if { node["percona"]["skip_passwords"] }
 end
 
@@ -108,7 +109,7 @@ template percona["main_config_file"] do
   owner "root"
   group "root"
   mode "0644"
-
+  sensitive true if Chef::Resource::Template.method_defined? :sensitive
   notifies :run, "execute[setup mysql datadir]", :immediately
   if node["percona"]["auto_restart"]
     notifies :restart, "service[mysql]", :immediately
@@ -119,6 +120,7 @@ end
 unless node["percona"]["skip_passwords"]
   execute "Update MySQL root password" do
     root_pw = passwords.root_password
+    sensitive true if Chef::Resource::Execute.method_defined? :sensitive
     command "mysqladmin --user=root --password='' password '#{root_pw}'"
     only_if "mysqladmin --user=root --password='' version"
   end
@@ -131,6 +133,7 @@ template "/etc/mysql/debian.cnf" do
   owner "root"
   group "root"
   mode "0640"
+  sensitive true if Chef::Resource::Template.method_defined? :sensitive
   if node["percona"]["auto_restart"]
     notifies :restart, "service[mysql]", :immediately
   end

--- a/recipes/replication.rb
+++ b/recipes/replication.rb
@@ -28,4 +28,5 @@ execute "mysql-set-replication" do
   command "/usr/bin/mysql #{root_pass} < #{replication_sql}"
   action :nothing
   subscribes :run, resources("template[#{replication_sql}]"), :immediately
+  sensitive true if Chef::Resource::Execute.method_defined? :sensitive
 end

--- a/spec/access_grants_spec.rb
+++ b/spec/access_grants_spec.rb
@@ -15,7 +15,8 @@ describe "percona::access_grants" do
     expect(chef_run).to create_template(grant_file).with(
       owner: "root",
       group: "root",
-      mode: "0600"
+      mode: "0600",
+      sensitive: true
     )
   end
 

--- a/spec/configure_server_spec.rb
+++ b/spec/configure_server_spec.rb
@@ -93,7 +93,8 @@ describe "percona::configure_server" do
       expect(chef_run).to create_template("/root/.my.cnf").with(
         owner: "root",
         group: "root",
-        mode: "0600"
+        mode: "0600",
+        sensitive: true
       )
 
       expect(chef_run).to render_file("/root/.my.cnf").with_content("s3kr1t")
@@ -152,7 +153,8 @@ describe "percona::configure_server" do
       expect(chef_run).to create_template("/mysql/my.cnf").with(
         owner: "root",
         group: "root",
-        mode: "0644"
+        mode: "0644",
+        sensitive: true
       )
 
       expect(chef_run).to render_file("/mysql/my.cnf").with_content(
@@ -174,7 +176,8 @@ describe "percona::configure_server" do
       expect(chef_run).to create_template(debian_cnf).with(
         owner: "root",
         group: "root",
-        mode: "0640"
+        mode: "0640",
+        sensitive: true
       )
 
       expect(chef_run).to render_file(debian_cnf).with_content("d3b1an")
@@ -200,7 +203,8 @@ describe "percona::configure_server" do
       expect(chef_run).to create_template("/etc/my.cnf").with(
         owner: "root",
         group: "root",
-        mode: "0644"
+        mode: "0644",
+        sensitive: true
       )
 
       resource = chef_run.template("/etc/my.cnf")

--- a/spec/replication_spec.rb
+++ b/spec/replication_spec.rb
@@ -37,7 +37,8 @@ describe "percona::replication" do
       expect(chef_run).to create_template(replication_sql).with(
         owner: "root",
         group: "root",
-        mode: "0600"
+        mode: "0600",
+        sensitive: true
       )
       expect(chef_run).to render_file(replication_sql).with_content("s3kr1t")
     end


### PR DESCRIPTION
Chef 11.14.2 + version now support functionality of sensitive flag which can be used for protecting sensitive information on chef resources \[1\].
This change will allow users to use sensitive flags with chef-percona cookbook

\[1\]: https://tickets.opscode.com/browse/CHEF-5098