### PR TITLE
Avoid uninstall of mysql-libs (i.e. Percona shared package) when not needed

### DIFF
--- a/README.md
+++ b/README.md
@@ -655,6 +655,7 @@ Many thanks go to the following [contributors](https://github.com/phlipper/chef-
     * fix mysql root password update check
 * **[@arnesund](https://github.com/arnesund)**
     * fix package list for clusters based on CentOS
+    * avoid uninstall of `mysql-libs` when not needed
 
 
 ## License

--- a/recipes/cluster.rb
+++ b/recipes/cluster.rb
@@ -26,6 +26,7 @@ when "debian"
 when "rhel"
   package "mysql-libs" do
     action :remove
+    not_if "rpm -qa | grep -q '#{node["percona"]["cluster"]["package"]}'"
   end
 
   # This is required for `socat` per:

--- a/spec/cluster_spec.rb
+++ b/spec/cluster_spec.rb
@@ -52,6 +52,11 @@ describe "percona::cluster" do
         end.converge(described_recipe)
       end
 
+      before do
+        stub_command("rpm -qa | grep -q 'Percona-XtraDB-Cluster-55'")
+          .and_return(false)
+      end
+
       specify do
         expect(chef_run).to remove_package "mysql-libs"
 
@@ -94,6 +99,11 @@ describe "percona::cluster" do
         ChefSpec::SoloRunner.new(env_options) do |node|
           node.set["percona"]["version"] = "5.6"
         end.converge(described_recipe)
+      end
+
+      before do
+        stub_command("rpm -qa | grep -q 'Percona-XtraDB-Cluster-56'")
+          .and_return(false)
       end
 
       specify do


### PR DESCRIPTION
This is #251 rebased on top of the latest master.