### PR TITLE
Remove workaround to get XtraDB Cluster 5.6 installed on CentOS 7

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -10,6 +10,7 @@ platforms:
   - name: ubuntu-12.04
   - name: ubuntu-14.04
   - name: centos-6.5
+  - name: centos-7.0
 
 suites:
   <% %w[5.5 5.6].each do |version| %>

--- a/README.md
+++ b/README.md
@@ -656,6 +656,7 @@ Many thanks go to the following [contributors](https://github.com/phlipper/chef-
 * **[@arnesund](https://github.com/arnesund)**
     * fix package list for clusters based on CentOS
     * avoid uninstall of `mysql-libs` when not needed
+    * fix XtraDB Cluster 5.6 installation on CentOS 7
 
 
 ## License

--- a/README.md
+++ b/README.md
@@ -285,7 +285,7 @@ default["percona"]["server"]["bind_address"]  = "127.0.0.1"
 end
 
 # Fine Tuning
-default["percona"]["server"]["key_buffer"] = "16M"
+default["percona"]["server"]["key_buffer_size"] = "16M"
 default["percona"]["server"]["max_allowed_packet"] = "64M"
 default["percona"]["server"]["thread_stack"] = "192K"
 default["percona"]["server"]["query_alloc_block_size"] = "16K"
@@ -328,7 +328,7 @@ default["percona"]["server"]["log_long_format"] = false
 default["percona"]["server"]["bulk_insert_buffer_size"] = "64M"
 
 # MyISAM Specific
-default["percona"]["server"]["myisam_recover"] = "BACKUP"
+default["percona"]["server"]["myisam_recover_options"] = "BACKUP"
 default["percona"]["server"]["myisam_sort_buffer_size"] = "128M"
 default["percona"]["server"]["myisam_max_sort_file_size"] = "10G"
 default["percona"]["server"]["myisam_repair_threads"] = 1

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -79,7 +79,7 @@ default["percona"]["server"]["bind_address"]  = "127.0.0.1"
 end
 
 # Fine Tuning
-default["percona"]["server"]["key_buffer"] = "16M"
+default["percona"]["server"]["key_buffer_size"] = "16M"
 default["percona"]["server"]["max_allowed_packet"] = "64M"
 default["percona"]["server"]["thread_stack"] = "192K"
 default["percona"]["server"]["query_alloc_block_size"] = "16K"
@@ -122,7 +122,7 @@ default["percona"]["server"]["log_long_format"] = false
 default["percona"]["server"]["bulk_insert_buffer_size"] = "64M"
 
 # MyISAM Specific
-default["percona"]["server"]["myisam_recover"] = "BACKUP"
+default["percona"]["server"]["myisam_recover_options"] = "BACKUP"
 default["percona"]["server"]["myisam_sort_buffer_size"] = "128M"
 default["percona"]["server"]["myisam_max_sort_file_size"] = "10G"
 default["percona"]["server"]["myisam_repair_threads"] = 1

--- a/recipes/cluster.rb
+++ b/recipes/cluster.rb
@@ -33,13 +33,6 @@ when "rhel"
   # www.percona.com/doc/percona-xtradb-cluster/5.6/installation/yum_repo.html
   include_recipe "yum-epel"
 
-  # This follows the originals posters workaround found here:
-  #    https://bugs.launchpad.net/percona-toolkit/+bug/1031427
-  # The package dependency PITA is actually a bug in the XtraDB Cluster package
-  # and not toolkit hence it's inclusion here before the actual XtraDB Cluster
-  # package install.
-  package "Percona-Server-shared-compat"
-
   package node["percona"]["cluster"]["package"]
 end
 

--- a/spec/cluster_spec.rb
+++ b/spec/cluster_spec.rb
@@ -62,7 +62,6 @@ describe "percona::cluster" do
 
         expect(chef_run).to include_recipe "yum-epel"
 
-        expect(chef_run).to install_package "Percona-Server-shared-compat"
         expect(chef_run).to install_package centos_cluster_package
       end
     end
@@ -111,7 +110,6 @@ describe "percona::cluster" do
 
         expect(chef_run).to include_recipe "yum-epel"
 
-        expect(chef_run).to install_package "Percona-Server-shared-compat"
         expect(chef_run).to install_package centos_cluster_package
       end
     end

--- a/templates/default/my.cnf.cluster.erb
+++ b/templates/default/my.cnf.cluster.erb
@@ -106,7 +106,7 @@ performance_schema=<%= node["percona"]["server"]["performance_schema"] ? "ON" : 
 #
 # * Fine Tuning
 #
-key_buffer = <%= node["percona"]["server"]["key_buffer"] %>
+key_buffer_size = <%= node["percona"]["server"]["key_buffer_size"] %>
 
 # The maximum size of a query packet the server can handle as well as
 # maximum query size server can process (Important when working with
@@ -397,7 +397,7 @@ max_allowed_packet = <%= node["percona"]["server"]["max_allowed_packet"] %>
 #no-auto-rehash # faster start of mysql but no tab completition
 
 [isamchk]
-key_buffer = <%= node["percona"]["server"]["key_buffer"] %>
+key_buffer_size = <%= node["percona"]["server"]["key_buffer_size"] %>
 
 #
 # * IMPORTANT: Additional settings that can override those from this file!

--- a/templates/default/my.cnf.cluster.erb
+++ b/templates/default/my.cnf.cluster.erb
@@ -131,7 +131,7 @@ thread_cache_size = <%= node["percona"]["server"]["thread_cache_size"] %>
 
 # This replaces the startup script and checks MyISAM tables if needed
 # the first time they are touched
-myisam-recover = <%= node["percona"]["server"]["myisam_recover"] %>
+myisam-recover-options = <%= node["percona"]["server"]["myisam_recover_options"] %>
 
 # back_log is the number of connections the operating system can keep in
 # the listen queue, before the MySQL connection manager thread has

--- a/templates/default/my.cnf.main.erb
+++ b/templates/default/my.cnf.main.erb
@@ -171,7 +171,7 @@ thread_cache_size = <%= node["percona"]["server"]["thread_cache_size"] %>
 
 # This replaces the startup script and checks MyISAM tables if needed
 # the first time they are touched
-myisam-recover = <%= node["percona"]["server"]["myisam_recover"] %>
+myisam-recover-options = <%= node["percona"]["server"]["myisam_recover_options"] %>
 
 # back_log is the number of connections the operating system can keep in
 # the listen queue, before the MySQL connection manager thread has
@@ -385,7 +385,7 @@ myisam_max_sort_file_size = <%= node["percona"]["server"]["myisam_max_sort_file_
 myisam_repair_threads = <%= node["percona"]["server"]["myisam_repair_threads"] %>
 
 # Automatically check and repair not properly closed MyISAM tables.
-<% if node["percona"]["server"]["myisam_recover"] %>
+<% if node["percona"]["server"]["myisam_recover_options"] %>
 myisam_recover
 <% end %>
 

--- a/templates/default/my.cnf.main.erb
+++ b/templates/default/my.cnf.main.erb
@@ -89,7 +89,7 @@ performance_schema=<%= node["percona"]["server"]["performance_schema"] ? "ON" : 
 
 # * Fine Tuning
 #
-key_buffer = <%= node["percona"]["server"]["key_buffer"] %>
+key_buffer_size = <%= node["percona"]["server"]["key_buffer_size"] %>
 
 # The maximum size of a query packet the server can handle as well as
 # maximum query size server can process (Important when working with
@@ -556,7 +556,7 @@ max_allowed_packet = <%= node["percona"]["server"]["max_allowed_packet"] %>
 #no-auto-rehash # faster start of mysql but no tab completition
 
 [isamchk]
-key_buffer = <%= node["percona"]["server"]["key_buffer"] %>
+key_buffer_size = <%= node["percona"]["server"]["key_buffer_size"] %>
 
 ##### custom configurations go here
 <% unless node["percona"]["conf"].nil? or node["percona"]["conf"].empty? %>


### PR DESCRIPTION
This is #241 rebased on top of the latest master.