### PR TITLE
added config flag for innodb_import_table_from_xtrabackup

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -155,7 +155,7 @@ default["percona"]["server"]["innodb_log_files_in_group"] = 2
 default["percona"]["server"]["innodb_max_dirty_pages_pct"] = 80
 default["percona"]["server"]["innodb_flush_method"] = "O_DIRECT"
 default["percona"]["server"]["innodb_lock_wait_timeout"] = 120
-
+default["percona"]["server"]["innodb_import_table_from_xtrabackup"] = 0
 # Performance Schema
 default["percona"]["server"]["performance_schema"] = false
 

--- a/templates/default/my.cnf.main.erb
+++ b/templates/default/my.cnf.main.erb
@@ -541,6 +541,9 @@ innodb_commit_concurrency=0
 
 innodb_open_files=2000
 
+# set this to 1 if you like to import single tables from xtrabackup snapshot
+innodb_import_table_from_xtrabackup = <%= node["percona"]["server"]["innodb_import_table_from_xtrabackup"] %>
+
 #
 # * Security Features
 #


### PR DESCRIPTION
I added the flag for importing tables from xtrabackup into the table space. default value is disabled.
@see http://www.percona.com/doc/percona-server/5.5/management/innodb_expand_import.html#innodb_import_table_from_xtrabackup