### PR TITLE
Another configuration file sync for cluster support

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -114,7 +114,7 @@ default["percona"]["server"]["query_cache_size"] = "64M"
 default["percona"]["server"]["query_cache_limit"] = "2M"
 
 # Logging and Replication
-default["percona"]["server"]["sync_binlog"] = 1
+default["percona"]["server"]["sync_binlog"] = node["percona"]["server"]["role"] == "cluster" ? 0 : 1
 default["percona"]["server"]["slow_query_log"] = 1
 default["percona"]["server"]["slow_query_logdir"] = "/var/log/mysql"
 default["percona"]["server"]["slow_query_log_file"] = "#{node["percona"]["server"]["slow_query_logdir"]}/mysql-slow.log"

--- a/templates/default/my.cnf.cluster.erb
+++ b/templates/default/my.cnf.cluster.erb
@@ -136,6 +136,63 @@ read_rnd_buffer_size = <%= node["percona"]["server"]["read_rnd_buffer_size"] %>
 # to a higher value.
 thread_stack = <%= node["percona"]["server"]["thread_stack"] %>
 
+# query_alloc_block_size controls how much memory is reserved for
+# parsing SQL statements and some other junk.  I increase it on boxes
+# that run complex queries to reduce possible memory fragmentation.  YMMV
+# default is 8k
+query_alloc_block_size = <%= node["percona"]["server"]["query_alloc_block_size"] %>
+
+# if your OS supports it, you can lock the buffer pool into memory
+# with this option to prevent swapping.  I'm not sure if linux supports this
+# but Solaris does.  On linux, using the swapiness sysctl is probably nearly
+# as effective.
+<% if node["percona"]["server"]["memlock"] %>
+memlock
+<% end %>
+
+# Set the default transaction isolation level. Levels available are:
+# READ-UNCOMMITTED, READ-COMMITTED, REPEATABLE-READ, SERIALIZABLE
+
+# REPEATABLE-READ requires next-key locks.  If your application isn't sensitive # to 'phantom rows', (it probably isn't) then read-committed is fine.  Feel
+# free to change this to REPEATABLE-READ at a small performance penalty if it
+# makes you feel better.
+transaction_isolation = <%= node["percona"]["server"]["transaction_isolation"] %>
+
+# Maximum size for internal (in-memory) temporary tables. If a table
+# grows larger than this value, it is automatically converted to disk
+# based table This limitation is for a single table. There can be many
+# of them.  Also, if max_heap_table_size < tmp_table_size, it will be used
+# as the limit instead, so making it bigger than that  is not useful.
+tmp_table_size = <%= node["percona"]["server"]["tmp_table_size"] %>
+
+# Storage engine which is used by default when creating new tables, if not
+# specified differently during the CREATE TABLE statement.
+default_storage_engine = <%= node["percona"]["server"]["default_storage_engine"] %>
+
+# Maximum allowed size for a single HEAP (in memory) table. This option
+# is a protection against the accidential creation of a very large HEAP
+# table which could otherwise use up all memory resources.
+max_heap_table_size = <%= node["percona"]["server"]["max_heap_table_size"] %>
+
+# Sort buffer is used to perform sorts for some ORDER BY and GROUP BY
+# queries. If sorted data does not fit into the sort buffer, a disk
+# based merge sort is used instead - See the "Sort_merge_passes"
+# status variable. Allocated per thread if sort is needed.
+sort_buffer_size = <%= node["percona"]["server"]["sort_buffer_size"] %>
+
+# This buffer is used for the optimization of full JOINs (JOINs without
+# indexes). Such JOINs are very bad for performance in most cases
+# anyway, but setting this variable to a large value reduces the
+# performance impact. See the "Select_full_join" status variable for a
+# count of full JOINs. Allocated per thread if full join is found
+join_buffer_size = <%= node["percona"]["server"]["join_buffer_size"] %>
+
+# How many threads we should keep in a cache for reuse. When a client
+# disconnects, the client's threads are put in the cache if there aren't
+# more than thread_cache_size threads from before.  This greatly reduces
+# the amount of thread creations needed if you have a lot of new
+# connections. (Normally this doesn't give a notable performance
+# improvement if you have a good thread implementation.)
 thread_cache_size = <%= node["percona"]["server"]["thread_cache_size"] %>
 
 # This replaces the startup script and checks MyISAM tables if needed
@@ -187,13 +244,32 @@ query_cache_size  = <%= node["percona"]["server"]["query_cache_size"] %>
 # As of 5.1 you can enable the  at runtime!
 #log_type           = FILE
 #general_log    = /var/log/mysql/mysql.log
+
+# sync_binlog ensures that all writes to the binary log are immediately
+# flushed to disk.  This is important, especially for replication, because
+# if the server crashes and has not written all of the binary log to disk (and flushed it)
+# then some rows will not make it to the slave
+sync_binlog = <%= node["percona"]["server"]["sync_binlog"] %>
+
 #
 # Error logging goes to syslog due to /etc/mysql/conf.d/mysqld_safe_syslog.cnf.
 #
 # Here you can see queries with especially long duration
-#log_slow_queries = /var/log/mysql/mysql-slow.log
-#long_query_time = 2
-#log-queries-not-using-indexes
+# Slow queries are queries which take more than the
+# amount of time defined in "long_query_time" or which do not use
+# indexes well, if log_long_format is enabled. It is normally good idea
+# to have this turned on if you frequently add new queries to the
+# system.
+slow_query_log = <%= node["percona"]["server"]["slow_query_log"] %>
+slow_query_log_file  = <%= node["percona"]["server"]["slow_query_log_file"] %>
+
+# All queries taking more than this amount of time (in seconds) will be
+# trated as slow. Do not use "1" as a value here, as this will result in
+# even very fast queries being logged from time to time (as MySQL
+# currently measures time with second accuracy only).
+long_query_time = <%= node["percona"]["server"]["long_query_time"] %>
+
+# log-queries-not-using-indexes
 #
 # The following can be used as easy to replay backup logs or for replication.
 # note: if you are setting up a replication slave, see README.Debian about
@@ -238,9 +314,73 @@ read_only
 <% end %>
 
 
-#log_bin      = /var/log/mysql/mysql-bin.log
+log_bin          = <%= node["percona"]["server"]["datadir"] %>/mysql-bin.log
 expire_logs_days = <%= node["percona"]["server"]["expire_logs_days"] %>
 max_binlog_size  = <%= node["percona"]["server"]["max_binlog_size"] %>
+binlog_format    = <%= node["percona"]["server"]["binlog_format"] %>
+
+<% node["percona"]["server"]["binlog_do_db"].each do |db_name| %>
+binlog-do-db     = <%= db_name %>
+<% end -%>
+
+# The size of the cache to hold the SQL statements for the binary log
+# during a transaction. If you often use big, multi-statement
+# transactions you can increase this value to get more performance. All
+# statements from transactions are buffered in the binary log cache and
+# are being written to the binary log at once after the COMMIT.  If the
+# transaction is larger than this value, temporary file on disk is used
+# instead.  This buffer is allocated per connection on first update
+# statement in transaction
+binlog_cache_size = <%= node["percona"]["server"]["binlog_cache_size"] %>
+
+# Enable the full query log. Every query (even ones with incorrect
+# syntax) that the server receives will be logged. This is useful for
+# debugging, it is usually disabled in production use.
+#log
+
+# Log warnings to the error log
+<% if node["percona"]["server"]["log_warnings"] %>
+log_warnings
+<% end %>
+
+# Log more information in the slow query log. Normally it is good to
+# have this turned on. This will enable logging of queries that are not
+# using indexes in addition to long running queries.
+<% if node["percona"]["server"]["log_long_format"] %>
+log_long_format
+<% end %>
+
+# MyISAM uses special tree-like cache to make bulk inserts (that is,
+# INSERT ... SELECT, INSERT ... VALUES (...), (...), ..., and LOAD DATA
+# INFILE) faster. This variable limits the size of the cache tree in
+# bytes per thread. Setting it to 0 will disable this optimisation.  Do
+# not set it larger than "key_buffer_size" for optimal performance.
+# This buffer is allocated when a bulk insert is detected.
+bulk_insert_buffer_size = <%= node["percona"]["server"]["bulk_insert_buffer_size"] %>
+
+# This buffer is allocated when MySQL needs to rebuild the index in
+# REPAIR, OPTIMIZE, ALTER table statements as well as in LOAD DATA INFILE
+# into an empty table. It is allocated per thread so be careful with
+# large settings.
+myisam_sort_buffer_size = <%= node["percona"]["server"]["myisam_sort_buffer_size"] %>
+
+# The maximum size of the temporary file MySQL is allowed to use while
+# recreating the index (during REPAIR, ALTER TABLE or LOAD DATA INFILE.
+# If the file-size would be bigger than this, the index will be created
+# through the key cache (which is slower).
+myisam_max_sort_file_size = <%= node["percona"]["server"]["myisam_max_sort_file_size"] %>
+
+# If a table has more than one index, MyISAM can use more than one
+# thread to repair them by sorting in parallel. This makes sense if you
+# have multiple CPUs and plenty of memory.
+myisam_repair_threads = <%= node["percona"]["server"]["myisam_repair_threads"] %>
+
+# Automatically check and repair not properly closed MyISAM tables.
+<% if node["percona"]["server"]["myisam_recover_options"] %>
+myisam_recover
+<% end %>
+
+
 #binlog_do_db   = include_database_name
 #binlog_ignore_db = include_database_name
 #
@@ -294,7 +434,7 @@ innodb_file_format = <%= node["percona"]["server"]["innodb_file_format"] %>
 
 # Set this option if you would like the InnoDB tablespace files to be
 # stored in another location. By default this is the MySQL datadir.
-<% if !node["percona"]["server"]["innodb_data_home_dir"].empty? %>
+<% unless node["percona"]["server"]["innodb_data_home_dir"].empty? %>
 innodb_data_home_dir = <%= node["percona"]["server"]["innodb_data_home_dir"] %>
 <% end %>
 
@@ -407,6 +547,18 @@ max_allowed_packet = <%= node["percona"]["server"]["max_allowed_packet"] %>
 
 [isamchk]
 key_buffer_size = <%= node["percona"]["server"]["key_buffer_size"] %>
+
+##### custom configurations go here
+<% unless node["percona"]["conf"].nil? or node["percona"]["conf"].empty? %>
+<% node["percona"]["conf"].keys.each do |category| %>
+
+    <%= "[#{category}]" %>
+    <% node["percona"]["conf"][category].keys.each do |key| %>
+        <%= "#{key} = #{node["percona"]["conf"][category][key]}" %>
+    <% end %>
+
+<% end %>
+<% end %>
 
 #
 # * IMPORTANT: Additional settings that can override those from this file!


### PR DESCRIPTION
I'm trying to keep the clustered configuration template as flexible
as the standalone.  I've left out what seems more or less useless for
a clustered intstance (replication stuff, mostly) but am happy to do a
full sync of folks think it's useful.

    * Add missing sections from my.cnf.main.erb to my.cnf.cluster.erb
        * noteable tunables: join_buffer_size, sort_buffer_size, tmp_table_size
        * allow clustered installs to set their slow query log
    * Ensure sync_binlog retains default of 0 for galera cluster
        * I've read this is best practise for Galera, and didn't want to change
        the default by having it tunable
    * Allow clustered installs to make use of the custom config. cookbook attributes
     via '["percona"]["conf"]' like standalone installs