### PR TITLE
De-duplicate directroy creation for slow query log

### DIFF
--- a/recipes/configure_server.rb
+++ b/recipes/configure_server.rb
@@ -91,10 +91,12 @@ unless includedir.empty?  # ~FC023
 end
 
 # setup slow_query_logdir directory
-directory slow_query_logdir do
-  owner user
-  group user
-  recursive true
+unless slow_query_logdir.eql? logdir
+  directory slow_query_logdir do
+    owner user
+    group user
+    recursive true
+  end
 end
 
 # define the service

--- a/recipes/configure_server.rb
+++ b/recipes/configure_server.rb
@@ -91,12 +91,11 @@ unless includedir.empty?  # ~FC023
 end
 
 # setup slow_query_logdir directory
-unless slow_query_logdir.eql? logdir
-  directory slow_query_logdir do
-    owner user
-    group user
-    recursive true
-  end
+directory slow_query_logdir do
+  owner user
+  group user
+  recursive true
+  not_if { slow_query_logdir.eql? logdir }
 end
 
 # define the service

--- a/spec/configure_server_spec.rb
+++ b/spec/configure_server_spec.rb
@@ -191,6 +191,27 @@ describe "percona::configure_server" do
     end
   end
 
+  describe "custom slow query log directory" do
+    let(:chef_run) do
+      ChefSpec::SoloRunner.new do |node|
+        node.set["percona"]["server"]["slow_query_logdir"] = "/var/log/mysql/slow_query"
+      end.converge(described_recipe)
+    end
+
+    before do
+      stub_command("mysqladmin --user=root --password='' version")
+        .and_return(true)
+    end
+
+    it "creates the slow query log directory" do
+      expect(chef_run).to create_directory("/var/log/mysql/slow_query").with(
+        owner: "mysql",
+        group: "mysql",
+        recursive: true
+      )
+    end
+  end
+
   describe "`rhel` platform family" do
     let(:chef_run) do
       env_options = { platform: "centos", version: "6.5" }

--- a/spec/configure_server_spec.rb
+++ b/spec/configure_server_spec.rb
@@ -194,7 +194,7 @@ describe "percona::configure_server" do
   describe "custom slow query log directory" do
     let(:chef_run) do
       ChefSpec::SoloRunner.new do |node|
-        node.set["percona"]["server"]["slow_query_logdir"] = "/var/log/mysql/slow_query"
+        node.set["percona"]["server"]["slow_query_logdir"] = "/var/log/slowq"
       end.converge(described_recipe)
     end
 
@@ -204,7 +204,7 @@ describe "percona::configure_server" do
     end
 
     it "creates the slow query log directory" do
-      expect(chef_run).to create_directory("/var/log/mysql/slow_query").with(
+      expect(chef_run).to create_directory("/var/log/slowq").with(
         owner: "mysql",
         group: "mysql",
         recursive: true


### PR DESCRIPTION
This PR detects if slow query log directory is same as log directory, and if they are same, do not call directory resource again for slow query log.

It suppress following warning while executing chefspec:

WARN: Cloning resource attributes for directory[/var/log/mysql] from prior resource (CHEF-3694)
WARN: Previous directory[/var/log/mysql]: /tmp/d20150429-14078-g09lm9/cookbooks/percona/recipes/configure_server.rb:71:in `from_file'
WARN: Current  directory[/var/log/mysql]: /tmp/d20150429-14078-g09lm9/cookbooks/percona/recipes/configure_server.rb:94:in `from_file'
