### PR TITLE
template for my.cnf cluster should not contain binlog_format for server

### DIFF
--- a/templates/default/my.cnf.cluster.erb
+++ b/templates/default/my.cnf.cluster.erb
@@ -317,7 +317,6 @@ read_only
 log_bin          = <%= node["percona"]["server"]["datadir"] %>/mysql-bin.log
 expire_logs_days = <%= node["percona"]["server"]["expire_logs_days"] %>
 max_binlog_size  = <%= node["percona"]["server"]["max_binlog_size"] %>
-binlog_format    = <%= node["percona"]["server"]["binlog_format"] %>
 
 <% node["percona"]["server"]["binlog_do_db"].each do |db_name| %>
 binlog-do-db     = <%= db_name %>


### PR DESCRIPTION
- binlog_format config option was twice in the template
  my.cnf.cluster.erb
- removed the binlog_format for the server attribute