### PR TITLE
cluster specific settings for my.cnf and client packages

### DIFF
--- a/attributes/client.rb
+++ b/attributes/client.rb
@@ -19,9 +19,15 @@ when "debian"
                 else ""
                 end
 
-  default["percona"]["client"]["packages"] = %W[
-    libperconaserverclient#{abi_version}-dev percona-server-client-#{version}
-  ]
+  if Array(node["percona"]["server"]["role"]).include?("cluster")
+    default["percona"]["client"]["packages"] = %W[
+      libperconaserverclient#{abi_version}-dev percona-xtradb-cluster-client-#{version}
+    ]
+  else
+    default["percona"]["client"]["packages"] = %W[
+      libperconaserverclient#{abi_version}-dev percona-server-client-#{version}
+    ]
+  end
 when "rhel"
   if Array(node["percona"]["server"]["role"]).include?("cluster")
     default["percona"]["client"]["packages"] = %W[

--- a/recipes/configure_server.rb
+++ b/recipes/configure_server.rb
@@ -118,7 +118,11 @@ end
 
 # setup the main server config file
 template percona["main_config_file"] do
-  source "my.cnf.#{server["role"] == "cluster" ? "cluster" : "main"}.erb"
+  if Array(server["role"]).include?("cluster")
+    source "my.cnf.cluster.erb"
+  else
+    source "my.cnf.main.erb"
+  end
   owner "root"
   group "root"
   mode "0644"


### PR DESCRIPTION
- install percona-xtradb-cluster-client when percona.server.role includes "cluster"
- fixed check for percona.server.role when determining which template to use for my.cnf