### PR TITLE
Add binlog_ignore_db attribute and associated template variables.

### DIFF
--- a/README.md
+++ b/README.md
@@ -336,6 +336,7 @@ default["percona"]["server"]["slow_query_log_file"] = "#{node["percona"]["server
 default["percona"]["server"]["long_query_time"] = 2
 default["percona"]["server"]["server_id"] = 1
 default["percona"]["server"]["binlog_do_db"] = []
+default["percona"]["server"]["binlog_ignore_db"] = []
 default["percona"]["server"]["expire_logs_days"] = 10
 default["percona"]["server"]["max_binlog_size"] = "100M"
 default["percona"]["server"]["binlog_cache_size"] = "1M"

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -120,6 +120,7 @@ default["percona"]["server"]["slow_query_log_file"] = "#{node["percona"]["server
 default["percona"]["server"]["long_query_time"] = 2
 default["percona"]["server"]["server_id"] = 1
 default["percona"]["server"]["binlog_do_db"] = []
+default["percona"]["server"]["binlog_ignore_db"] = []
 default["percona"]["server"]["expire_logs_days"] = 10
 default["percona"]["server"]["max_binlog_size"] = "100M"
 default["percona"]["server"]["binlog_cache_size"] = "1M"

--- a/templates/default/my.cnf.cluster.erb
+++ b/templates/default/my.cnf.cluster.erb
@@ -323,6 +323,10 @@ binlog_format    = <%= node["percona"]["server"]["binlog_format"] %>
 binlog-do-db     = <%= db_name %>
 <% end -%>
 
+<% node["percona"]["server"]["binlog_ignore_db"].each do |db_name| %>
+binlog-ignore-db = <%= db_name %>
+<% end %>
+
 # The size of the cache to hold the SQL statements for the binary log
 # during a transaction. If you often use big, multi-statement
 # transactions you can increase this value to get more performance. All
@@ -381,8 +385,6 @@ myisam_recover
 <% end %>
 
 
-#binlog_do_db   = include_database_name
-#binlog_ignore_db = include_database_name
 #
 # * InnoDB
 #

--- a/templates/default/my.cnf.main.erb
+++ b/templates/default/my.cnf.main.erb
@@ -319,6 +319,10 @@ binlog_format    = <%= node["percona"]["server"]["binlog_format"] %>
 binlog-do-db     = <%= db_name %>
 <% end -%>
 
+<% node["percona"]["server"]["binlog_ignore_db"].each do |db_name| %>
+binlog-ignore-db = <%= db_name %>
+<% end %>
+
 # The size of the cache to hold the SQL statements for the binary log
 # during a transaction. If you often use big, multi-statement
 # transactions you can increase this value to get more performance. All
@@ -412,8 +416,6 @@ myisam_recover
 <% end %>
 
 
-#binlog_do_db   = include_database_name
-#binlog_ignore_db = include_database_name
 #
 # * InnoDB
 #


### PR DESCRIPTION
This adds `binlog-ignore-db` to `my.cnf` via a new attribute `binlog_ignore_db`.