### PR TITLE
Add version restrictions on three MySQL directives.

### DIFF
--- a/templates/default/my.cnf.cluster.erb
+++ b/templates/default/my.cnf.cluster.erb
@@ -103,9 +103,11 @@ old_passwords = <%= @old_passwords %>
 bind-address = <%= node["percona"]["server"]["bind_address"] %>
 <% end %>
 
+<%- if node["percona"]["version"] >= "5.5" %>
 # As of 5.6.6 performance_schema is enabled by default. This allows it to be
 # explicitly turned on or off as needed across all mysql versions
 performance_schema=<%= node["percona"]["server"]["performance_schema"] ? "ON" : "OFF" %>
+<% end %>
 
 #
 # * Fine Tuning
@@ -197,7 +199,12 @@ thread_cache_size = <%= node["percona"]["server"]["thread_cache_size"] %>
 
 # This replaces the startup script and checks MyISAM tables if needed
 # the first time they are touched
+<%- if node["percona"]["version"] < "5.5" %>
+myisam-recover = <%= node["percona"]["server"]["myisam_recover_options"] %>
+<% else %>
 myisam-recover-options = <%= node["percona"]["server"]["myisam_recover_options"] %>
+<% end %>
+
 
 # back_log is the number of connections the operating system can keep in
 # the listen queue, before the MySQL connection manager thread has

--- a/templates/default/my.cnf.main.erb
+++ b/templates/default/my.cnf.main.erb
@@ -87,9 +87,11 @@ bind-address = <%= node["percona"]["server"]["bind_address"] %>
 <% end %>
 #
 
+<%- if node["percona"]["version"] >= "5.5" %>
 # As of 5.6.6 performance_schema is enabled by default. This allows it to be
 # explicitly turned on or off as needed across all mysql versions
 performance_schema=<%= node["percona"]["server"]["performance_schema"] ? "ON" : "OFF" %>
+<% end %>
 
 # * Fine Tuning
 #
@@ -180,7 +182,11 @@ thread_cache_size = <%= node["percona"]["server"]["thread_cache_size"] %>
 
 # This replaces the startup script and checks MyISAM tables if needed
 # the first time they are touched
+<%- if node["percona"]["version"] < "5.5" %>
+myisam-recover = <%= node["percona"]["server"]["myisam_recover_options"] %>
+<% else %>
 myisam-recover-options = <%= node["percona"]["server"]["myisam_recover_options"] %>
+<% end %>
 
 # back_log is the number of connections the operating system can keep in
 # the listen queue, before the MySQL connection manager thread has
@@ -561,7 +567,7 @@ innodb_commit_concurrency=0
 
 innodb_open_files=<%= node["percona"]["server"]["innodb_open_files"] %>
 
-<% if node["percona"]["version"] < "5.6" %>
+<% if node["percona"]["version"] == "5.5" %>
 # set this to 1 if you like to import single tables from xtrabackup snapshot
 innodb_import_table_from_xtrabackup = <%= node["percona"]["server"]["innodb_import_table_from_xtrabackup"] %>
 <% end %>


### PR DESCRIPTION
The default values as configured for Percona Server 5.1 caused the server to abort startup.

Here are the changes:

- `performance_schema` is not valid in versions < 5.5.
- `myisam-recover` was renamed to `myisam-recover-options` in 5.5.3.
- `innodb_import_table_from_xtrabackup` is not valid in versions < 5.5.