### PR TITLE
Define old_passwords only when there is a value defined.

### DIFF
--- a/templates/default/my.cnf.cluster.erb
+++ b/templates/default/my.cnf.cluster.erb
@@ -91,10 +91,12 @@ innodb_locks_unsafe_for_binlog = <%= node["percona"]["cluster"]["innodb_locks_un
 innodb_autoinc_lock_mode       = <%= node["percona"]["cluster"]["innodb_autoinc_lock_mode"] %>
 
 
+<% if @old_passwords %>
 #
 # For compatibility to other Debian packages that still use
 # libmysqlclient10 and libmysqlclient12.
 old_passwords = <%= @old_passwords %>
+<% end %>
 
 #
 # Instead of skip-networking the default is now to listen only on

--- a/templates/default/my.cnf.main.erb
+++ b/templates/default/my.cnf.main.erb
@@ -74,10 +74,12 @@ net_read_timeout = <%= node["percona"]["server"]["net_read_timeout"] %>
 connect_timeout  = <%= node["percona"]["server"]["connect_timeout"] %>
 wait_timeout     = <%= node["percona"]["server"]["wait_timeout"] %>
 
+<% if @old_passwords %>
 #
 # For compatibility to other Debian packages that still use
 # libmysqlclient10 and libmysqlclient12.
 old_passwords = <%= @old_passwords %>
+<% end %>
 
 #
 # Instead of skip-networking the default is now to listen only on


### PR DESCRIPTION
In Percona Server 5.1, I get this when starting MySQL with `old_passwords` set to the empty string:

```
150515 16:06:36 [Warning] mysqld: ignoring option '--old-passwords' due to invalid value ''
```