### PR TITLE
Suppress warning CHEF-3694 on chefspec for log dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -732,6 +732,7 @@ Many thanks go to the following [contributors](https://github.com/phlipper/chef-
     * add `skip_slave_start` attribute
 * **[@joelhandwell](https://github.com/joelhandwell)**
     * fix duplication of slow query log directory creation
+    * suppress warning CHEF-3694 for log dir
 * **[@bitpusher-real](https://github.com/bitpusher-real)**
     * add `binlog_ignore_db` attribute
     * add version restrictions on three MySQL directives
@@ -740,8 +741,6 @@ Many thanks go to the following [contributors](https://github.com/phlipper/chef-
     * add `replication_sql` attribute
 * **[@jklare](https://github.com/jklare)**
     * fix cluster specific settings for `my.cnf` and client packages
-* **[@joelhandwell](https://github.com/joelhandwell)**
-    * suppress warning CHEF-3694 for log dir
 
 
 ## License

--- a/README.md
+++ b/README.md
@@ -740,6 +740,8 @@ Many thanks go to the following [contributors](https://github.com/phlipper/chef-
     * add `replication_sql` attribute
 * **[@jklare](https://github.com/jklare)**
     * fix cluster specific settings for `my.cnf` and client packages
+* **[@joelhandwell](https://github.com/joelhandwell)**
+    * suppress warning CHEF-3694 for log dir
 
 
 ## License

--- a/recipes/configure_server.rb
+++ b/recipes/configure_server.rb
@@ -68,7 +68,8 @@ directory datadir do
 end
 
 # setup the log directory
-directory logdir do
+directory "log directory" do
+  path logdir
   owner user
   group user
   recursive true
@@ -91,7 +92,8 @@ unless includedir.empty?  # ~FC023
 end
 
 # setup slow_query_logdir directory
-directory slow_query_logdir do
+directory "slow query log directory" do
+  path slow_query_logdir
   owner user
   group user
   recursive true

--- a/spec/configure_server_spec.rb
+++ b/spec/configure_server_spec.rb
@@ -46,7 +46,17 @@ describe "percona::configure_server" do
     end
 
     it "creates the log directory" do
-      expect(chef_run).to create_directory("/var/log/mysql").with(
+      expect(chef_run).to create_directory("log directory").with(
+        path: "/var/log/mysql",
+        owner: "mysql",
+        group: "mysql",
+        recursive: true
+      )
+    end
+
+    it "do not create duplicated slow query log directory" do
+      expect(chef_run).to_not create_directory("slow query log directory").with(
+        path: "/var/log/mysql",
         owner: "mysql",
         group: "mysql",
         recursive: true


### PR DESCRIPTION
This PR will suppuress following warning in case running chefspec using percona cookbook in a wrapper cookbook:

```
[2015-05-22T22:23:57+00:00] WARN: Cloning resource attributes for directory[/var/log/mysql] from prior resource (CHEF-3694)
[2015-05-22T22:23:57+00:00] WARN: Previous directory[/var/log/mysql]: /tmp/d20150522-11171-wy6kil/cookbooks/percona/recipes/configure_server.rb:71:in `from_file'
[2015-05-22T22:23:57+00:00] WARN: Current  directory[/var/log/mysql]: /tmp/d20150522-11171-wy6kil/cookbooks/percona/recipes/configure_server.rb:94:in `from_file'
```