### PR TITLE
Fix duplicated attribute

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -24,7 +24,8 @@ suites:
   - name: client_<%= version.tr(".", "") %>
     attributes:
       percona:
-        apt_keyserver: hkp://pgp.mit.edu:80
+        apt:
+          keyserver: hkp://pgp.mit.edu:80
         version: "<%= version %>"
     run_list:
       - recipe[percona::client]
@@ -33,7 +34,8 @@ suites:
   - name: server_<%= version.tr(".", "") %>
     attributes:
       percona:
-        apt_keyserver: hkp://pgp.mit.edu:80
+        apt:
+          keyserver: hkp://pgp.mit.edu:80
         version: "<%= version %>"
         server:
           datadir: /tmp/mysql

--- a/README.md
+++ b/README.md
@@ -253,7 +253,7 @@ default["percona"]["main_config_file"] = value_for_platform_family(
   "debian" => "/etc/mysql/my.cnf",
   "rhel" => "/etc/my.cnf"
 )
-default["percona"]["keyserver"] = "keys.gnupg.net"
+default["percona"]["apt"]["keyserver"] = "hkp://keys.gnupg.net:80"
 default["percona"]["encrypted_data_bag"] = "passwords"
 default["percona"]["encrypted_data_bag_secret_file"] = ""
 default["percona"]["use_chef_vault"] = false

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -35,7 +35,6 @@ default["percona"]["main_config_file"] = value_for_platform_family(
   "debian" => "/etc/mysql/my.cnf",
   "rhel" => "/etc/my.cnf"
 )
-default["percona"]["keyserver"] = "keys.gnupg.net"
 default["percona"]["encrypted_data_bag"] = "passwords"
 default["percona"]["encrypted_data_bag_secret_file"] = ""
 default["percona"]["encrypted_data_bag_item_mysql"] = "mysql"

--- a/attributes/package_repo.rb
+++ b/attributes/package_repo.rb
@@ -4,15 +4,16 @@
 #
 
 default["percona"]["use_percona_repos"] = true
-default["percona"]["apt_uri"] = "http://repo.percona.com/apt"
-default["percona"]["apt_keyserver"] = "hkp://keys.gnupg.net:80"
-default["percona"]["apt_key"] = "0x1C4CBDCDCD2EFD2A"
 
 arch = node["kernel"]["machine"] == "x86_64" ? "x86_64" : "i386"
 pversion = value_for_platform(
   "amazon" => { "default" => "latest" },
   "default" => node["platform_version"].to_i
 )
+
+default["percona"]["apt"]["key"] = "0x1C4CBDCDCD2EFD2A"
+default["percona"]["apt"]["keyserver"] = "hkp://keys.gnupg.net:80"
+default["percona"]["apt"]["uri"] = "http://repo.percona.com/apt"
 
 default["percona"]["yum"]["description"] = "Percona Packages"
 default["percona"]["yum"]["baseurl"] = "http://repo.percona.com/centos/#{pversion}/os/#{arch}/"

--- a/recipes/package_repo.rb
+++ b/recipes/package_repo.rb
@@ -17,11 +17,11 @@ when "debian"
   end
 
   apt_repository "percona" do
-    uri node["percona"]["apt_uri"]
+    uri node["percona"]["apt"]["uri"]
     distribution node["lsb"]["codename"]
     components ["main"]
-    keyserver node["percona"]["apt_keyserver"]
-    key node["percona"]["apt_key"]
+    keyserver node["percona"]["apt"]["keyserver"]
+    key node["percona"]["apt"]["key"]
   end
 
 when "rhel"


### PR DESCRIPTION
* remove keyserver from default attributes
* namespace apt attributes following yum example

I'd consider changing the default keyserver to `keyserver.ubuntu.com` or `pgp.mit.edu` etc. since I was getting a lot of errors lately from `keys.gnupg.net`.