### PR TITLE
Added skip_install_db option.

### DIFF
--- a/recipes/configure_server.rb
+++ b/recipes/configure_server.rb
@@ -107,10 +107,12 @@ service "mysql" do
 end
 
 # install db to the data directory
-execute "setup mysql datadir" do
-  command "mysql_install_db --defaults-file=#{percona["main_config_file"]} --user=#{user}" # rubocop:disable LineLength
-  not_if "test -f #{datadir}/mysql/user.frm"
-  action :nothing
+unless node["percona"]["skip_install_db"]
+	execute "setup mysql datadir" do
+		command "mysql_install_db --defaults-file=#{percona["main_config_file"]} --user=#{user}" # rubocop:disable LineLength
+		not_if "test -f #{datadir}/mysql/user.frm"
+		action :nothing
+	end
 end
 
 # install SSL certificates before config phase


### PR DESCRIPTION
Added an option to disable database initialization. This is useful for
replication setups where mysql_install_db would create conflicts
between the slave and master.