### PR TITLE
Added skip_install_db option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,9 @@ Set the `["percona"]["skip_passwords"]` attribute to skip setting up passwords. 
 
 Set the `['percona']['skip_configure']` attribute to skip having the server recipe include the configure\_server recipe directly after install. This is mostly useful in a wrapper cookbook sort of context. Once skipped, you can then perform any pre-config actions your wrapper needs to, such as dropping a custom configuration file or init script or cleaning up incorrectly sized innodb logfiles. You can then include configure\_server where necessary.
 
+### Skip install\_db
+Set the `["percona"]["skip_install_db"]` attribute to skip running mysql\_install\_db. Useful for replication setups where you still want the database to be partially initialized but you don't want it to be populated with the default tables.
+
 #### mysql item
 
 The mysql item should contain entries for root, backup, and replication. If no value is found, the cookbook will fall back to the default non-encrypted password.

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -43,6 +43,7 @@ default["percona"]["encrypted_data_bag_item_ssl_replication"] = "ssl_replication
 default["percona"]["use_chef_vault"] = false
 default["percona"]["skip_passwords"] = false
 default["percona"]["skip_configure"] = false
+default["percona"]["skip_install_db"] = false
 
 # Start percona server on boot
 default["percona"]["server"]["enable"] = true

--- a/recipes/configure_server.rb
+++ b/recipes/configure_server.rb
@@ -107,10 +107,12 @@ service "mysql" do
 end
 
 # install db to the data directory
-execute "setup mysql datadir" do
-  command "mysql_install_db --defaults-file=#{percona["main_config_file"]} --user=#{user}" # rubocop:disable LineLength
-  not_if "test -f #{datadir}/mysql/user.frm"
-  action :nothing
+unless node["percona"]["skip_install_db"]
+	execute "setup mysql datadir" do
+		command "mysql_install_db --defaults-file=#{percona["main_config_file"]} --user=#{user}" # rubocop:disable LineLength
+		not_if "test -f #{datadir}/mysql/user.frm"
+		action :nothing
+	end
 end
 
 # install SSL certificates before config phase

--- a/recipes/configure_server.rb
+++ b/recipes/configure_server.rb
@@ -108,11 +108,11 @@ end
 
 # install db to the data directory
 unless node["percona"]["skip_install_db"]
-	execute "setup mysql datadir" do
-		command "mysql_install_db --defaults-file=#{percona["main_config_file"]} --user=#{user}" # rubocop:disable LineLength
-		not_if "test -f #{datadir}/mysql/user.frm"
-		action :nothing
-	end
+  execute "setup mysql datadir" do
+    command "mysql_install_db --defaults-file=#{percona["main_config_file"]} --user=#{user}" # rubocop:disable LineLength
+    not_if "test -f #{datadir}/mysql/user.frm"
+    action :nothing
+  end
 end
 
 # install SSL certificates before config phase


### PR DESCRIPTION
Added skip install db option, useful for slave replication where you want the rest of the database to be setup but you don't want the database to be populated.