### PR TITLE
remove toolkit workaround #345

### DIFF
--- a/recipes/toolkit.rb
+++ b/recipes/toolkit.rb
@@ -5,13 +5,6 @@
 
 include_recipe "percona::package_repo"
 
-# Workaround a bug in the RPM packaging of percona-toolkit. Otherwise, it'll
-#   try to pull in Percona-Server-shared-51, which will conflict with 5.5.
-# https://bugs.launchpad.net/percona-toolkit/+bug/1031427
-if platform_family?("rhel") && node["percona"]["version"].match(/5\.[15]/)
-  package "Percona-Server-shared-compat"
-end
-
 package "percona-toolkit" do
   options "--force-yes" if platform_family?("debian")
 end

--- a/spec/toolkit_spec.rb
+++ b/spec/toolkit_spec.rb
@@ -1,10 +1,6 @@
 require "spec_helper"
 
 describe "percona::toolkit" do
-  let(:centos_package) do
-    "Percona-Server-shared-compat"
-  end
-
   let(:toolkit_package) do
     "percona-toolkit"
   end
@@ -15,8 +11,6 @@ describe "percona::toolkit" do
     end
 
     specify do
-      expect(chef_run).to_not install_package(centos_package)
-
       expect(chef_run).to install_package(toolkit_package)
     end
   end
@@ -31,7 +25,6 @@ describe "percona::toolkit" do
       end
 
       specify do
-        expect(chef_run).to install_package(centos_package)
         expect(chef_run).to install_package(toolkit_package)
       end
     end
@@ -45,8 +38,6 @@ describe "percona::toolkit" do
       end
 
       specify do
-        expect(chef_run).to_not install_package(centos_package)
-
         expect(chef_run).to install_package(toolkit_package)
       end
     end


### PR DESCRIPTION
The bug referenced in the toolkit recipe has been resolved for percona-toolkit and is no longer necessary. See issue #345 as well as the latest posts describing the fix here: https://bugs.launchpad.net/percona-toolkit/+bug/1031427