### PR TITLE
Update/Add attributes

### DIFF
--- a/attributes/client.rb
+++ b/attributes/client.rb
@@ -31,11 +31,13 @@ when "debian"
 when "rhel"
   if Array(node["percona"]["server"]["role"]).include?("cluster")
     default["percona"]["client"]["packages"] = %W[
-      Percona-XtraDB-Cluster-devel-#{version} Percona-XtraDB-Cluster-client-#{version}
+      Percona-XtraDB-Cluster-client-#{version}
     ]
+      #Percona-XtraDB-Cluster-devel-#{version} 
   else
     default["percona"]["client"]["packages"] = %W[
-      Percona-Server-devel-#{version} Percona-Server-client-#{version}
+      Percona-Server-client-#{version}
     ]
+      #Percona-Server-devel-#{version} 
   end
 end

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -102,11 +102,12 @@ default["percona"]["server"]["max_heap_table_size"] = "64M"
 default["percona"]["server"]["sort_buffer_size"] = "8M"
 default["percona"]["server"]["join_buffer_size"] = "8M"
 default["percona"]["server"]["thread_cache_size"] = 16
-default["percona"]["server"]["back_log"] = 50
+default["percona"]["server"]["back_log"] = 50           # >= 5.6.6, -1 (autosized)
 default["percona"]["server"]["max_connections"] = 30
 default["percona"]["server"]["max_connect_errors"] = 9_999_999
 default["percona"]["server"]["sql_modes"] = []
 default["percona"]["server"]["table_cache"] = 8192
+default["percona"]["server"]["table_definition_cache"] = 4096   # >= 5.6.8, Default -1 (autosized)
 default["percona"]["server"]["group_concat_max_len"] = 4096
 default["percona"]["server"]["expand_fast_index_creation"] = false
 default["percona"]["server"]["read_rnd_buffer_size"] = 262_144
@@ -146,6 +147,7 @@ default["percona"]["server"]["read_buffer_size"] = "8M"
 default["percona"]["server"]["skip_innodb"] = false
 default["percona"]["server"]["innodb_additional_mem_pool_size"] = "32M"
 default["percona"]["server"]["innodb_buffer_pool_size"] = "128M"
+default["percona"]["server"]["innodb_buffer_pool_instances"] = 8
 default["percona"]["server"]["innodb_data_file_path"] = "ibdata1:10M:autoextend"
 default["percona"]["server"]["innodb_autoextend_increment"] = "128M"
 default["percona"]["server"]["innodb_open_files"] = 2000

--- a/recipes/cluster.rb
+++ b/recipes/cluster.rb
@@ -17,8 +17,8 @@ end
 # set default package attributes
 version = node["percona"]["version"]
 node.default["percona"]["cluster"]["package"] = value_for_platform_family(
-  "debian" => "percona-xtradb-cluster-#{version.tr(".", "")}",
-  "rhel" => "Percona-XtraDB-Cluster-#{version.tr(".", "")}"
+  "rhel" => "Percona-XtraDB-Cluster-#{version.tr(".", "")}",
+  "debian" => "percona-xtradb-cluster-#{version.tr(".", "")}"
 )
 
 # install packages

--- a/templates/default/my.cnf.cluster.erb
+++ b/templates/default/my.cnf.cluster.erb
@@ -237,6 +237,8 @@ table_open_cache        = <%= node["percona"]["server"]["table_cache"] %>
 table_cache             = <%= node["percona"]["server"]["table_cache"] %>
 <%- end %>
 
+table_definition_cache             = <%= node["percona"]["server"]["table_definition_cache"] %>
+
 #thread_concurrency     = 10
 #
 #
@@ -426,6 +428,8 @@ innodb_additional_mem_pool_size = <%= node["percona"]["server"]["innodb_addition
 
 # This config file assumes a main memory of at least 8G
 innodb_buffer_pool_size = <%= node["percona"]["server"]["innodb_buffer_pool_size"] %>
+
+innodb_buffer_pool_instances = <%= node["percona"]["server"]["innodb_buffer_pool_instances"] %>
 
 # InnoDB stores data in one or more data files forming the tablespace.
 # If you have a single logical drive for your data, a single

--- a/templates/default/my.cnf.main.erb
+++ b/templates/default/my.cnf.main.erb
@@ -219,6 +219,8 @@ table_open_cache        = <%= node["percona"]["server"]["table_cache"] %>
 table_cache             = <%= node["percona"]["server"]["table_cache"] %>
 <%- end %>
 
+table_definition_cache             = <%= node["percona"]["server"]["table_definition_cache"] %>
+
 #thread_concurrency     = 10
 #
 # * Query Cache Configuration
@@ -457,6 +459,8 @@ innodb_additional_mem_pool_size = <%= node["percona"]["server"]["innodb_addition
 
 # This config file assumes a main memory of at least 8G
 innodb_buffer_pool_size = <%= node["percona"]["server"]["innodb_buffer_pool_size"] %>
+
+innodb_buffer_pool_instances = <%= node["percona"]["server"]["innodb_buffer_pool_instances"] %>
 
 # InnoDB stores data in one or more data files forming the tablespace.
 # If you have a single logical drive for your data, a single


### PR DESCRIPTION
add
- innodb_buffer_pool_instances
- table_definition_cache

Not intended, but contain as accident (reject if you find it strange):
- remove "Percona-XtraDB-Cluster-devel" package on client, as I found it failing (constrains on packages) on RHEL an not needed OOTB.
-  Minor, swap order on node.default["percona"]["cluster"]["package"] - no reason in general